### PR TITLE
Ignore installed external packages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 .. New release notes go here
 
+* Ignore installed external (``-e``) packages.
+
 1.1.1 (2018-04-15)
 ------------------
 

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -30,7 +30,7 @@ def read_pip(filename):
     return lines
 
 
-def get_package_versions(lines):
+def get_package_versions(lines, ignore_external=False):
     """Return a dictionary of package versions."""
     versions = {}
     for line in lines:
@@ -42,7 +42,7 @@ def get_package_versions(lines):
         if line.startswith('https://'):
             continue
 
-        if line.startswith('-e'):
+        if ignore_external and line.startswith('-e'):
             continue
 
         name, version_plus = line.split('==', 1)
@@ -56,7 +56,7 @@ def get_mismatches(requirements_file_path):
     pip_lines = read_pip(requirements_file_path)
 
     expected = get_package_versions(pip_lines)
-    actual = get_package_versions(pip_freeze())
+    actual = get_package_versions(pip_freeze(), ignore_external=True)
 
     mismatches = {}
     for name, version in expected.items():

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -42,6 +42,9 @@ def get_package_versions(lines):
         if line.startswith('https://'):
             continue
 
+        if line.startswith('-e'):
+            continue
+
         name, version_plus = line.split('==', 1)
         versions[name.lower()] = version_plus.split(' ', 1)[0]
 

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -104,6 +104,16 @@ class TestGetMismatches(object):
 
         assert get_mismatches(requirements_path) == {}
 
+    @patch('pip_lock.pip_freeze')
+    def test_editable_packages(self, pip_freeze, tmpdir):
+        pip_freeze.return_value = [
+            '-e git+git@github.com:YPlan/pip-lock.git@efac0eef8072d73b001b1bae0731c1d58790ac4b#egg=pip-lock',
+            'package==1.1',
+        ]
+        requirements_path = create_file(tmpdir, 'requirements.txt', 'package==1.1')
+
+        assert get_mismatches(requirements_path) == {}
+
 
 class TestPrintErrors(object):
 


### PR DESCRIPTION
As per [requirements.txt](https://pip.readthedocs.io/en/1.1/requirements.html) documentation - add support for external packages.

Currently `pip-lock` fails with exception `ValueError: not enough values to unpack (expected 2, got 1)` if it encounters external package in `pip freeze` output.