### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 
 .. New release notes go here
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 1.2.0 (2018-07-25)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ Install with **pip**:
 
     pip install pip-lock
 
+Python 3.4+ supported.
+
 Example usage
 =============
 

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import sys
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,7 @@
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
-mock
-modernize
 multilint
 Pygments
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,26 +6,17 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
-funcsigs==1.0.2           # via mock, pytest
-futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-mock==2.0.0
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
-pbr==5.1.1                # via mock
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0               # via mock, more-itertools, multilint, pathlib2, pytest
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,7 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 line_length = 120
 multi_line_output = 5
 not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -16,10 +12,10 @@ def get_version(filename):
 version = get_version('pip_lock.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 
@@ -33,7 +29,7 @@ setup(
     url='https://github.com/adamchainz/pip-lock',
     py_modules=['pip_lock'],
     include_package_data=True,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="ISCL",
     zip_safe=False,
     keywords='pip, requirements',
@@ -42,8 +38,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -1,14 +1,8 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 from pip_lock import check_requirements, get_mismatches, get_package_versions, print_errors, read_pip
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def create_file(tmpdir, name, text):

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,12 @@
 [tox]
 envlist =
-    py{27,36},
-    py{27,36}-codestyle
+    py3,
+    py3-codestyle
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
 install_command = pip install --no-deps {opts} {packages}
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
 
 [testenv:py36-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* In `setup.py`, remove use of `codecs.open`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
👉   * In `requirements.in`,  remove `futures` pin, `mock`, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports, and remove universal wheel building