### PR TITLE
Drop changelog marker from HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,9 +1,6 @@
-.. :changelog:
-
+=======
 History
 =======
-
-.. New release notes go here
 
 2.1.0 (2019-12-19)
 ------------------


### PR DESCRIPTION
No longer needed as the file is not contatenated with README.