### PR TITLE
Ignore packages installed directly from wheels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Fix to ignore packages installed directly from wheels, for example pip itself
+  on Heroku, which will output its location in ``pip freeze`` as
+  ``pip @ file:///tmp/pip-20.1.1-py2.py3-none-any.whl``.
+
 2.1.0 (2019-12-19)
 ------------------
 

--- a/src/pip_lock.py
+++ b/src/pip_lock.py
@@ -21,7 +21,7 @@ def read_pip(filename):
     return lines
 
 
-def get_package_versions(lines, ignore_external=False):
+def get_package_versions(lines, ignore_external_and_at=False):
     """Return a dictionary of package versions."""
     versions = {}
     for line in lines:
@@ -33,8 +33,9 @@ def get_package_versions(lines, ignore_external=False):
         if line.startswith("https://"):
             continue
 
-        if ignore_external and line.startswith("-e"):
-            continue
+        if ignore_external_and_at:
+            if line.startswith("-e") or " @ " in line:
+                continue
 
         full_name, version_and_extras = line.split("==", 1)
         # Strip extras
@@ -50,7 +51,7 @@ def get_mismatches(requirements_file_path):
     pip_lines = read_pip(requirements_file_path)
 
     expected = get_package_versions(pip_lines)
-    actual = get_package_versions(pip_freeze(), ignore_external=True)
+    actual = get_package_versions(pip_freeze(), ignore_external_and_at=True)
 
     mismatches = {}
     for name, version in expected.items():

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -103,12 +103,22 @@ class TestGetMismatches:
         assert get_mismatches(requirements_path) == {}
 
     @mock.patch("pip_lock.pip_freeze")
-    def test_editable_packages(self, pip_freeze, tmpdir):
+    def test_editable_packages_ignored(self, pip_freeze, tmpdir):
         pip_freeze.return_value = [
             (
                 "-e git+git@github.com:adamchainz/pip-lock.git@"
                 + "efac0eef8072d73b001b1bae0731c1d58790ac4b#egg=pip-lock"
             ),
+            "package==1.1",
+        ]
+        requirements_path = create_file(tmpdir, "requirements.txt", "package==1.1")
+
+        assert get_mismatches(requirements_path) == {}
+
+    @mock.patch("pip_lock.pip_freeze")
+    def test_at_packages_ignored(self, pip_freeze, tmpdir):
+        pip_freeze.return_value = [
+            "pip @ file:///tmp/pip-20.1.1-py2.py3-none-any.whl",
             "package==1.1",
         ]
         requirements_path = create_file(tmpdir, "requirements.txt", "package==1.1")


### PR DESCRIPTION
Fixes a bug seen on Heroku since a recent update.