### PR TITLE
Do not enforce checks for external git requirements

### DIFF
--- a/src/pip_lock/__init__.py
+++ b/src/pip_lock/__init__.py
@@ -33,7 +33,7 @@ def get_package_versions(
         if len(line) == 0 or line.startswith(("#", "-")):
             continue
 
-        if line.startswith("https://"):
+        if line.startswith("https://") or line.startswith("git+"):
             continue
 
         if ignore_external_and_at:

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -60,6 +60,10 @@ class TestGetPackageVersion:
     def test_ignore_urls(self):
         assert get_package_versions(["https://www.google.com"]) == {}
 
+    def test_ignore_git_urls(self):
+        url = "git+https://git@github.com/adamchainz/pip-lock.git@80361b8#egg=pip-lock"
+        assert get_package_versions([url]) == {}
+
 
 class TestGetMismatches:
     @mock.patch("pip_lock.pip_freeze")


### PR DESCRIPTION
We have a private package on GitHub which we need to install in a project. Private GitHub repos do not allow to download the tar archive without auth info. We explored the available solutions and it appears that hardcoding the auth info in the requirements.txt seems the only way to make it work. To avoid storing the token in plain text we are using git+ssh protocol with pub+private key pair. As of now your package seems to break with git+ssh requirements.