### PR TITLE
Make it much faster

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+* Make the package much faster by using ``importlib.metadata`` to get installed
+  versions, rather than ``pip freeze``. This saves most of the import time
+  (local benchmark: 200ms down to 10ms) and halves the run time (230ms to
+  100ms).
+
 2.5.0 (2021-10-05)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir=
 packages = find:
 include_package_data = True
 install_requires =
-    pip>=10.0.0
+    importlib-metadata ; python_version < "3.8"
 python_requires = >=3.6
 zip_safe = False
 


### PR DESCRIPTION
`importlib.metadata.version()` gives us the version of a package and nothing else that we don't need.

It also returns the versions of editable and file-installed packages. I guess they don't need special casing now... I don't think this will cause any problems but if it does we can fix.