### PR TITLE
Fix matching packages with dots in their names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ History
 
 * Restore behaviour of ignoring requirements declared with `Pip VCS support <https://pip.pypa.io/en/stable/topics/vcs-support/>`__.
 
+* Read all installed packages with ``importlib.metadata``, rather than trying to look up by name.
+  This allows pip-lock to work for packages that have a dot in their name, which ``pip-compile`` normalizes to a dash.
+
 2.7.0 (2022-01-10)
 ------------------
 


### PR DESCRIPTION
There's a difference between pip and the installed name. Solve this by getting all names from `importlib.metadata` and normalize them the same way as pip.