### PR TITLE
Handle no version specified

### DIFF
--- a/src/pip_lock/__init__.py
+++ b/src/pip_lock/__init__.py
@@ -42,6 +42,10 @@ def parse_pip(lines: Iterable[str]) -> dict[str, str]:
         if VCS_RE.match(line):
             continue
 
+        if "==" not in line:
+            # Handle no version specified
+            continue
+
         full_name, version_and_extras = line.split("==", 1)
         # Strip extras and normalize
         name = normalize_name(full_name.split("[", 1)[0])

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -104,6 +104,9 @@ class TestParsePip:
     def test_ignore_at_https_urls(self):
         assert parse_pip(["foo @ https://example.com"]) == {}
 
+    def test_ignore_no_version(self):
+        assert parse_pip(["black[jupyter]"]) == {}
+
 
 class TestGetInstalled:
     def test_single(self):


### PR DESCRIPTION
If a dependency version is not specified in a requirements file, a value error is thrown when trying to [split the current line](https://github.com/adamchainz/pip-lock/blob/main/src/pip_lock/__init__.py#L45). This PR updates the parse loop to skip finding the version if no version is specified. 

One example of where this is an issue is when `black` and `black[jupyter]` are in a requirements file with both pinned at a specified version. In this case, if dependabot attempts to update one dependency, there will be a conflict when installing the requirements. This can be solved by not pinning one of the dependencies; however, this currently triggers an error when running `check_requirements`.