### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -8,14 +8,12 @@ from unittest import mock
 
 import pytest
 
-from pip_lock import (
-    check_requirements,
-    get_installed,
-    get_mismatches,
-    parse_pip,
-    print_errors,
-    read_pip,
-)
+from pip_lock import check_requirements
+from pip_lock import get_installed
+from pip_lock import get_mismatches
+from pip_lock import parse_pip
+from pip_lock import print_errors
+from pip_lock import read_pip
 
 
 @contextmanager


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
