### PR TITLE
Add typos tool to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,18 @@ repos:
   - id: check-toml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: https://github.com/crate-ci/typos
+  rev: 6cb49915af2e93e61f5f0d0a82216e28ad5c7c18  # frozen: v1
+  hooks:
+  - id: typos
+    exclude: |
+      (?x)^(
+        .*\.min\.css
+        |.*\.min\.js
+        |.*\.css\.map
+        |.*\.js\.map
+        |.*\.svg
+      )$
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 57b6ff7bf72affdd12c7f3fd6de761ba18a33b3a  # frozen: v2.5.1
   hooks:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+# Configuration file for 'typos' tool
+# https://github.com/crate-ci/typos
+
+[default]
+extend-ignore-re = [
+  # Single line ignore comments
+  "(?Rm)^.*(#|//)\\s*typos: ignore$",
+  # Multi-line ignore comments
+  "(?s)(#|//)\\s*typos: off.*?\\n\\s*(#|//)\\s*typos: on"
+]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -124,7 +124,7 @@ Changelog
   calling code's file. It's now the standard behaviour of relative to the
   current working directory. Passing an absolute path is recommended.
 * Make comparison of package names case-insensitive to work with
-  ``requirements.txt`` files that use a different case to the canoncial package
+  ``requirements.txt`` files that use a different case to the canonical package
   name. This can happen with ``pip-compile`` that always outputs lowercase
   names.
 * Fix 'mismatches' typo


### PR DESCRIPTION
This tool corrects common misspellings in all kinds of text files.
