### PR TITLE
Upgrade pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ urls = { Changelog = "https://github.com/adamchainz/pip-lock/blob/main/CHANGELOG
 
 [dependency-groups]
 test = [
-  "pytest",
+  "pytest>=9",
   "pytest-randomly",
 ]
 
@@ -97,11 +97,7 @@ warn_unreachable = true
 overrides = [ { module = "tests.*", allow_untyped_defs = true } ]
 
 [tool.pytest]
-ini_options.addopts = """\
-    --strict-config
-    --strict-markers
-    """
-ini_options.xfail_strict = true
+strict = true
 
 [tool.rstcheck]
 report_level = "ERROR"

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ test = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-randomly" },
 ]
 


### PR DESCRIPTION
Use the new proper TOML support [added in pytest 9](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05).
