### PR TITLE
Evaluate PEP 508 environment markers when parsing requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+* Evaluate PEP 508 environment markers when parsing requirements, so a
+  requirement whose marker does not apply to the current environment (for
+  example ``colorama==0.4.6 ; sys_platform == 'win32'`` on Linux) no longer
+  produces a false-positive mismatch.
+
 * Drop Python 3.9 support.
 
 2.13.0 (2025-09-09)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ classifiers = [
   "Topic :: Utilities",
   "Typing :: Typed",
 ]
-dependencies = []
+dependencies = [
+  "packaging",
+]
 urls = { Changelog = "https://github.com/adamchainz/pip-lock/blob/main/CHANGELOG.rst", Funding = "https://adamj.eu/books/", Repository = "https://github.com/adamchainz/pip-lock" }
 
 [dependency-groups]

--- a/src/pip_lock/__init__.py
+++ b/src/pip_lock/__init__.py
@@ -6,6 +6,8 @@ import sys
 from collections.abc import Iterable
 from importlib.metadata import distributions as get_distributions
 
+from packaging.markers import InvalidMarker, Marker
+
 
 def read_pip(filename: str) -> list[str]:
     """Return lines in pip file, concatenating included requirement files."""
@@ -38,7 +40,18 @@ def parse_pip(lines: Iterable[str]) -> dict[str, str]:
         if VCS_RE.match(line):
             continue
 
-        full_name, version_and_extras = line.split("==", 1)
+        # PEP 508 environment marker: skip requirements that don't apply to this environment
+        # (e.g. ``colorama==0.4.6 ; sys_platform == 'win32'`` on non-Windows).
+        requirement, _, marker = line.partition(";")
+        if marker.strip():
+            try:
+                if not Marker(marker).evaluate():
+                    continue
+            except InvalidMarker:
+                # Leave a malformed marker to pip; don't silently drop the requirement.
+                pass
+
+        full_name, version_and_extras = requirement.split("==", 1)
         # Strip extras and normalize
         name = normalize_name(full_name.split("[", 1)[0])
         version = version_and_extras.split(" ", 1)[0]

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -104,6 +104,26 @@ class TestParsePip:
     def test_ignore_at_https_urls(self):
         assert parse_pip(["foo @ https://example.com"]) == {}
 
+    def test_marker_matching_environment_is_kept(self):
+        assert parse_pip(["package==1.0 ; python_version >= '3'"]) == {
+            "package": "1.0",
+        }
+
+    def test_marker_not_matching_environment_is_skipped(self):
+        assert parse_pip(["package==1.0 ; python_version < '3'"]) == {}
+
+    def test_marker_without_surrounding_spaces(self):
+        assert parse_pip(["package==1.0;python_version<'3'"]) == {}
+
+    def test_marker_with_extras(self):
+        assert parse_pip(["package[extra]==1.0 ; python_version < '3'"]) == {}
+
+    def test_invalid_marker_is_kept(self):
+        # A malformed marker is left for pip to report, not silently dropped.
+        assert parse_pip(["package==1.0 ; not a valid marker"]) == {
+            "package": "1.0",
+        }
+
 
 class TestGetInstalled:
     def test_single(self):


### PR DESCRIPTION
Fixes #517.

`parse_pip` ignored PEP 508 environment markers, so a line like `colorama==0.4.6 ; sys_platform == 'win32'` was always treated as an expected requirement — a false-positive mismatch on any environment the marker excludes (e.g. `colorama` "missing" on Linux).

Now each requirement's marker is evaluated with `packaging.markers.Marker`, and lines whose marker doesn't apply to the current environment are skipped. A malformed marker is left for pip to report rather than silently dropping the requirement. Splitting on `;` before parsing also makes name/version extraction robust to markers written without surrounding spaces.

### Dependency note

This adds `packaging` to `dependencies` (the project was zero-dependency). Correct PEP 508 marker evaluation really needs it, and `packaging` is present in every environment where pip runs, so it shouldn't change pip-lock's practical footprint. If you'd rather keep the zero-dependency install, I'm happy to switch to an optional import (evaluate markers when `packaging` is importable, otherwise fall back to current behaviour) — just say the word.

### Tests

Added cases for a marker that matches (kept), doesn't match (skipped), has no surrounding spaces, is combined with extras, and is malformed (kept). The skip cases fail on `main` and pass with the change; full suite green; `ruff check`/`format` clean. Added a CHANGELOG entry.
